### PR TITLE
One button save when starting new project

### DIFF
--- a/src/app/dialogs/projectconfigdialog.py
+++ b/src/app/dialogs/projectconfigdialog.py
@@ -20,9 +20,9 @@ class ProjectConfigDialog(QDialog):
 
     def initUI(self): 
         self.resize(850,600)
-        self.teamConfig = TeamConfigWidget(parent=self, eventManager=self.eventConfigManager)
-        self.dirConfig = DirConfigWidget(parent=self, eventManager=self.eventConfigManager)
-        self.eventConfig = EventConfigWidget(parent=self, eventManager=self.eventConfigManager)
+        self.teamConfig = TeamConfigWidget(parent=self, eventManager=self.eventConfigManager, hide=True)
+        self.dirConfig = DirConfigWidget(parent=self, eventManager=self.eventConfigManager, hide=True)
+        self.eventConfig = EventConfigWidget(parent=self, eventManager=self.eventConfigManager, hide=True)
         self.vectorConfig = VectorConfigWidget(parent=self, eventManager=self.eventConfigManager)
         
         self.stack = QStackedWidget(self)
@@ -70,7 +70,10 @@ class ProjectConfigDialog(QDialog):
         msg.setStandardButtons(QMessageBox.Retry)
 
         if (self.vectorConfig.checkIfThereAreVectors() and self.dirConfig.validateInputs() and self.eventConfig.validateInputs()):
-            self.parent.updateView(2)
+            self.dirConfig.saveConfig()
+            self.eventConfig.save()
+            self.teamConfig.connect()
+            self.parent.updateView(1)
             self.accept()
         else:
             answer = msg.exec()

--- a/src/app/mainwindow.py
+++ b/src/app/mainwindow.py
@@ -9,6 +9,7 @@ from app.views.actionReportView import ActionReportView
 from app.dialogs.projectconfigdialog import ProjectConfigDialog
 #import dialog from edit vector configuration for edit Vector Process
 from app.widgets.vectorconfigwidget import VectorConfigWidget
+from app.widgets.eventconfigwidget import EventConfigWidget
 
 from processes.cleansing import CleansingThread
 from processes.ingestion import IngestionThread
@@ -34,12 +35,6 @@ class MainWindow(QMainWindow):
         self.processingView = ProcessingView(self)
         self.actionreportview = ActionReportView(self)
 
-        #Sets home pic        
-        # pic_label = QLabel()
-        # home_page = QPixmap("app/images/PICK_home.png")
-        # pic_label.setPixmap(home_page.scaled(self.width(),self.height(), QtCore.Qt.IgnoreAspectRatio, QtCore.Qt.FastTransformation))
-
-        # self.windowStack.addWidget(pic_label)
         self.windowStack.addWidget(self.analysisView)
         self.windowStack.addWidget(self.processingView)
         self.windowStack.addWidget(self.actionreportview)
@@ -77,7 +72,7 @@ class MainWindow(QMainWindow):
         self.newProject.triggered.connect(self.newProjectProcess)
 
         self.editConfig = QAction("Edit Configuration", self)
-        self.editConfig.triggered.connect(lambda: self.updateView(1))
+        self.editConfig.triggered.connect(self.editConfigDialog)
 
         self.editVectorConfig = QAction("Edit Vector Configuration", self)
         self.editVectorConfig.triggered.connect(self.editVecProcess)
@@ -90,7 +85,6 @@ class MainWindow(QMainWindow):
         self.editmenu.addAction(self.editVectorConfig)
     
     def newProjectProcess(self):
-        from PyQt5.QtWidgets import QDialog
         newProjectDialog = ProjectConfigDialog(self)
         newProjectDialog.exec()
 
@@ -118,7 +112,6 @@ class MainWindow(QMainWindow):
             pass
 
     def editVecProcess(self):
-        from PyQt5.QtWidgets import QDialog
         dialog = QDialog(self)
         container = QHBoxLayout()
         newVectorEditDialog = VectorConfigWidget(self)
@@ -128,6 +121,16 @@ class MainWindow(QMainWindow):
         dialog.setLayout(container) 
         doneBtn.clicked.connect(lambda: dialog.accept())
         dialog.exec()
+
+    def editConfigDialog(self): 
+        dialog = QDialog(self)
+        config = EventConfigWidget(parent=dialog, eventManager=EventConfigManager.get_instance())
+
+        container = QVBoxLayout()
+        container.addWidget(config)
+        dialog.setLayout(container)
+        dialog.exec()
+
 
     def updateView(self, n): 
         self.windowStack.setCurrentIndex(n)

--- a/src/app/widgets/dirconfigwidget.py
+++ b/src/app/widgets/dirconfigwidget.py
@@ -3,8 +3,9 @@ from PyQt5.QtWidgets import QDialog, QFileDialog, QWidget, QListWidget, QStacked
                             QHBoxLayout, QLabel, QPushButton, QRadioButton, QLineEdit, QDateTimeEdit, QSpacerItem, QSizePolicy
 
 class DirConfigWidget(QWidget):
-    def __init__(self, parent=None, eventManager=None):  
+    def __init__(self, hide=False, parent=None, eventManager=None):  
         super(DirConfigWidget, self).__init__(parent)
+        self.hide = hide
         self.eventConfigManager = eventManager
         self.initUI()
 
@@ -64,6 +65,8 @@ class DirConfigWidget(QWidget):
 
         saveBtn = QPushButton("Save")
         saveBtn.clicked.connect(self.saveConfig)
+        if self.hide == True: 
+            saveBtn.hide()
 
         dirViewContainer = QVBoxLayout()
         dirViewContainer.addLayout(viewLabelCon)

--- a/src/app/widgets/eventconfigwidget.py
+++ b/src/app/widgets/eventconfigwidget.py
@@ -2,8 +2,9 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget, QVBoxLayout,QHBoxLayout, QLabel, QPushButton, QLineEdit, QDateTimeEdit
 
 class EventConfigWidget(QWidget):
-    def __init__(self, parent=None, eventManager=None): 
+    def __init__(self, hide=False, parent=None, eventManager=None): 
         super(EventConfigWidget, self).__init__(parent) 
+        self.hide = hide
         self.eventConfigManager = eventManager
         self.initUI()
 
@@ -25,6 +26,8 @@ class EventConfigWidget(QWidget):
 
         saveBtn = QPushButton("Save")
         saveBtn.clicked.connect(self.save)
+        if self.hide == True: 
+            saveBtn.hide()
 
         eventConfigContainer = QVBoxLayout()
         eventConfigContainer.addWidget(self.viewLabel)
@@ -41,6 +44,11 @@ class EventConfigWidget(QWidget):
         self.setLayout(eventConfigContainer)
 
     def save(self):
+        print(self.parent())
+        print(self.hide)
+        if self.parent() and self.hide == False: 
+            self.parent().accept()
+            
         self.eventConfigManager.setEventAttributes(
             self.eventName.text(), 
             self.eventDescription.text(), 

--- a/src/app/widgets/teamconfigwidget.py
+++ b/src/app/widgets/teamconfigwidget.py
@@ -2,8 +2,9 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget, QTableView, QVBoxLayout,QHBoxLayout, QLabel, QPushButton, QRadioButton, QLineEdit
 
 class TeamConfigWidget(QWidget):
-    def __init__(self, parent=None, eventManager=None):
+    def __init__(self, hide=False, parent=None, eventManager=None):
         super(TeamConfigWidget, self).__init__(parent)  
+        self.hide = hide
         self.eventConfigManager = eventManager
         self.initUI()
 
@@ -31,6 +32,8 @@ class TeamConfigWidget(QWidget):
         self.connectBtn = QPushButton()
         self.connectBtn.setText("Connect")
         self.connectBtn.clicked.connect(self.connect)
+        if self.hide == True: 
+            self.connectBtn.hide()
 
 
         teamViewContainer = QVBoxLayout()

--- a/src/config/picksystem.ini
+++ b/src/config/picksystem.ini
@@ -1,12 +1,12 @@
 [SPLUNK]
-username = eirodriguez5
-password = RodH@ker2110
+username = YOUR CREDENTIALS
+password = YOUR CREDENTIALS
 host = localhost
 port = 8089
 
 [EVENT]
-name = fdsfsd
-description = fdsfsd
+name = jklfdsjlk
+description = jfkldsjfkls
 starttime = 01/01/2000, 00:00:00
 endtime = 01/01/2000, 00:00:00
 lead = True


### PR DESCRIPTION
Instead of having to click one button on every view of the start project dialog, make it so that it just saves all when it clicks the Start Project button